### PR TITLE
Clear old data from GoCardless

### DIFF
--- a/tools/import/old-data.js
+++ b/tools/import/old-data.js
@@ -69,6 +69,11 @@ async function syncData(overrides) {
 					postcode: override.delivery_postcode
 				} : {}
 			}});
+
+			// Clear data from GoCardless
+			await gocardless.customers.update(override.gc_customer_id, {
+				metadata: {}
+			});
 		} catch (error) {
 			console.log(override);
 			console.log(error.message);


### PR DESCRIPTION
While we are still transitioning to the new system we should clean up the data we were storing in GoCardless. This PR means we can keep syncing with GC while not overwriting future updates we make within the system.