### PR TITLE
Add ability to generate login and password reset codes

### DIFF
--- a/apps/members/views/partials/security.pug
+++ b/apps/members/views/partials/security.pug
@@ -3,11 +3,25 @@ dl.dl-horizontal
 	dt Tag
 	dd #{ member.tag.id ? member.tag.id : '–' }
 	if access( 'superadmin' )
-		if member.password.reset_code
-			dt Password Reset Code
-			dd
+		dt Login override
+		dd
+			if member.loginOverride && moment(member.loginOverride.expires).isAfter()
+				a(href='/login/' + member.loginOverride.code)= member.loginOverride.code
+			else
+				form(method='POST')
+					+csrf
+					input(type='hidden' name='action' value='login-override')
+					button.btn.btn-sm Generate link
+		dt Password reset
+		dd
+			if member.password.reset_code
 				a(href='/password-reset/code/' + member.password.reset_code)= member.password.reset_code
-		dt Password Tries
+			else
+				form(method='POST')
+					+csrf
+					input(type='hidden' name='action' value='password-reset')
+					button.btn.btn-sm Generate link
+		dt Password tries
 		dd #{ member.password.tries } #{ member.password.tries >= password_tries ? ' – Locked Out' : '' }
 		dt 2FA
 		dd #{ member.otp.activated ? 'Enabled' : 'Disabled' }

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -17,6 +17,7 @@
 	"flash-logged-out": "Logged out",
 	"flash-login-failed": "Login unsuccessful",
 	"flash-login-required": "You must be logged in",
+	"flash-login-code-invalid": "Login code is invalid or has expired",
 	"flash-already-logged-in": "You are already logged in",
 	"flash-inactive-membership": "Your membership is inactive",
 	"flash-403": "You do not have access to this area",
@@ -31,21 +32,13 @@
 
 	"flash-email-duplicate": "Email address already in use",
 
-	"flash-account-created": "Account created, please check your email for a registration link",
-	"flash-member-created": "Member successful created",
-
-	"flash-activation-error": "Activation code or password did not match",
-	"flash-activation-success": "You account is now active",
-	"flash-activation-updated": "Activation updated",
-
-	"flash-override-updated": "Signup override updated",
-
 	"flash-account-locked": "Maximum number of password attempts exceeded",
 	"flash-account-attempts": "There has been % attempt(s) to login to your account since you last logged in",
 
 	"flash-member-404": "Member not found",
+	"flash-member-login-override-generated": "Login override code generated",
+	"flash-member-password-reset-generated": "Password reset code generated",
 
-	"flash-profile-updated": "Profile updated",
 	"flash-account-updated": "Your account details have been updated",
 	"flash-delivery-updated": "Your delivery details have been updated",
 

--- a/src/models/members.js
+++ b/src/models/members.js
@@ -41,6 +41,10 @@ module.exports = {
 			unique: true,
 			sparse: true
 		},
+		loginOverride: {
+			code: String,
+			expires: Date
+		},
 		password: {
 			hash: {
 				type: String,


### PR DESCRIPTION
Useful for admin purposes to be able to generate login and password reset codes for members.

Login codes bypass the need to enter a password and are most useful for members who haven't set a password yet (e.g. partially completed signup)