### PR TITLE
Modify a member's export statuses and add them to new ones

### DIFF
--- a/apps/members/app.js
+++ b/apps/members/app.js
@@ -369,7 +369,7 @@ app.post( '/:uuid/exports', auth.isSuperAdmin, wrapAsync( async function( req, r
 		}, {
 			'exports.$.status': req.body.status
 		} );
-		req.flash('success', 'success!');
+		req.flash('success', 'exports-updated');
 
 	} else if (req.body.action === 'add') {
 		const exportDetails = await Exports.findById(req.body.export_id);
@@ -394,9 +394,9 @@ app.post( '/:uuid/exports', auth.isSuperAdmin, wrapAsync( async function( req, r
 				}
 			} );
 
-			req.flash( 'success', 'success!' );
+			req.flash( 'success', 'exports-added-one' );
 		} else {
-			req.flash( 'error', 'Not elgibile' );
+			req.flash( 'error', 'exports-ineligible' );
 		}
 	}
 

--- a/apps/members/views/exports.pug
+++ b/apps/members/views/exports.pug
@@ -1,0 +1,47 @@
+extends /src/views/base.pug
+
+block prepend title
+	- title = 'Exports'
+	- page = 'exports'
+
+block contents
+	.row
+		.col-md-3
+			include partials/sidebar.pug
+		.col-md-9
+			+page_header( title )
+
+			table.table
+				thead
+					tr
+						th Export name
+						th Status
+				tbody
+					for exprt in member.exports
+						tr
+							td= exprt.details.description
+							td
+								form(method="post").form-inline
+									+csrf
+									input(type="hidden" name="action" value="update")
+									input(type="hidden" name="export_id" value=exprt.export_id)
+									.form-group
+										select(name="status").form-control
+											for status in exportTypes[exprt.details.type].statuses
+												option(selected=status === exprt.status)= status
+									| &nbsp;&nbsp;
+									button.btn.btn-sm Update
+
+			h3 Add to export
+			form(method="post").form-horizontal
+				+csrf
+				input(type="hidden" name="action" value="add")
+				.form-group
+					label(for="export").col-md-3.control-label Export name
+					.col-md-4
+						select(id="export" name="export_id" required).form-control
+							option(value='' selected disabled)
+							for exportDetails in exports
+								option(value=exportDetails._id)= exportDetails.description
+				.col-md-offset-3.col-md-4
+					button.btn Add

--- a/apps/members/views/partials/sidebar.pug
+++ b/apps/members/views/partials/sidebar.pug
@@ -4,6 +4,7 @@ ul.nav.nav-pills.nav-stacked
 	if access( 'superadmin' )
 		li( class=( page == 'profile' ? 'active' : '' ) ): a( href='/members/' + member.uuid + '/profile' ) Profile
 		li( class=( page === 'emails' ? 'active' : '' ) ): a(href='/members/' + member.uuid + '/emails' ) Emails
+		li( class=( page === 'exports' ? ' active' : '' ) ): a(href='/members/' + member.uuid + '/exports' ) Exports
 		li( class=( page == 'gocardless' ? 'active' : '' ) ): a( href='/members/' + member.uuid + '/gocardless' ) GoCardless
 		li( class=( page == 'tag' ? 'active' : '' ) ): a( href='/members/' + member.uuid + '/tag' ) Tag
 		if ( member.otp.activated )

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -104,8 +104,10 @@
 
 	"flash-exports-created": "Export created",
 	"flash-exports-added": "Added members to export",
+	"flash-exports-added-one": "Added member to export",
 	"flash-exports-updated": "Updated export status",
 	"flash-exports-deleted": "Export deleted",
+	"flash-exports-ineligible": "Member is not eligible to be in this export.",
 
 	"flash-transactional-email-created": "Transactional email created",
 	"flash-transactional-email-sending": "Transactional email is sending!",


### PR DESCRIPTION
Allow admins to modify a user's status in an export. Useful for e.g. changing a user's status in an edition export if we need to resend them an edition