### PR TITLE
Always opt for best case expiry for payments

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -107,6 +107,7 @@ async function handlePaymentResourceEvent( event ) {
 	case 'confirmed': // Collected
 		await confirmPayment( payment );
 	case 'created': // Pending
+	case 'customer_approval_granted': // Customer has approved payment
 	case 'submitted': // Processing
 	case 'cancelled': // Cancelled
 	case 'failed': // Failed


### PR DESCRIPTION
This is mostly designed to address customer payment approval not resulting in an active membership until the payment has been confirmed. Once the customer has approved the payment, we should assume the payment will go through (like we do for normal payments)