### PR TITLE
Remove syslog support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2102,11 +2102,6 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -2468,18 +2463,6 @@
       "requires": {
         "extend.js": "0.0.2",
         "request": "^2.51.0"
-      }
-    },
-    "bunyan-syslog-unixdgram": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bunyan-syslog-unixdgram/-/bunyan-syslog-unixdgram-1.0.3.tgz",
-      "integrity": "sha512-l4G+WOgIf7OGFuA4dKXnHNBpTJUIHC8tlB39uUXMMTPID3UaweLDAfmK6y4eGTAIFUJFcCpyURxoKKtvBnsl5g==",
-      "requires": {
-        "@types/node": "*",
-        "assert-plus": "^1.0.0",
-        "json-stringify-safe": "^5.0.1",
-        "lodash.merge": "^4.6.0",
-        "unix-dgram": "^2.0.1"
       }
     },
     "busboy": {
@@ -7240,7 +7223,8 @@
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "dev": true
     },
     "lodash.mergewith": {
       "version": "4.6.1",
@@ -11233,22 +11217,6 @@
         "mkdirp": "^0.5.1",
         "os-tmpdir": "^1.0.1",
         "uid2": "0.0.3"
-      }
-    },
-    "unix-dgram": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.2.tgz",
-      "integrity": "sha512-QdKFZWzQ+cn9GloYcFw5Yp2DT7JyS5aAgMJPossiOwljrjQPqM8cOaJvkD+9aZhIVZ45OHonCvLWjm3l8fSNoA==",
-      "requires": {
-        "bindings": "^1.3.0",
-        "nan": "^2.10.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
-        }
       }
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "bunyan": "^1.8.12",
     "bunyan-middleware": "^0.8.0",
     "bunyan-slack": "0.0.10",
-    "bunyan-syslog-unixdgram": "^1.0.3",
     "chance": "^1.0.18",
     "connect-busboy": "0.0.2",
     "connect-mongodb-session": "^2.1.1",

--- a/src/js/logging.js
+++ b/src/js/logging.js
@@ -2,7 +2,6 @@ var config = require( __config );
 
 var bunyan = require( 'bunyan' ),
 	bunyanMiddleware = require( 'bunyan-middleware' ),
-	SyslogStream = require( 'bunyan-syslog-unixdgram' ),
 	BunyanSlack = require( 'bunyan-slack' );
 
 var crypto = require('crypto');
@@ -38,34 +37,6 @@ if ( config.log != undefined ) {
 		type: 'file',
 		path: config.log
 	});
-}
-
-if (config.syslog == true) {
-	var streamOptions = {
-		path: '/var/run/syslog'
-	};
-
-	var supported = true;
-	switch ( process.platform ) {
-	case 'darwin':
-		streamOptions.path = '/var/run/syslog';
-		break;
-	case 'linux':
-		streamOptions.path = '/dev/log';
-		break;
-	default:
-		console.error( 'syslog output only supported on Linux and OS X' );
-		supported = false;
-	}
-
-	if ( supported ) {
-		var stream = new SyslogStream( streamOptions );
-		bunyanConfig.streams.push( {
-			level: 'debug',
-			type: 'raw',
-			stream: stream
-		} );
-	}
 }
 
 if ( config.logSlack != undefined ) {


### PR DESCRIPTION
Package has a dependency on a lodash version which has a vulnerability
https://app.snyk.io/vuln/SNYK-JS-LODASHMERGE-173732

We never use the syslog capability in any case