### PR TITLE
Stop annual contributors from updating two weeks before renewal

### DIFF
--- a/apps/profile/apps/direct-debit/utils.js
+++ b/apps/profile/apps/direct-debit/utils.js
@@ -1,9 +1,19 @@
 const moment = require('moment');
 
+// Sometimes monthly subscriptions can have slightly longer than a month left
+// if the billing date changes slightly, but we should always count them as
+// having less than a month left
 function calcSubscriptionMonthsLeft(user) {
-	return moment.utc(user.memberPermission.date_expires).diff(moment.utc(), 'months');
+	return user.gocardless.period === 'monthly' ? 0 :
+		moment.utc(user.memberPermission.date_expires).diff(moment.utc(), 'months');
+}
+
+function canChangeSubscription(user) {
+	return user.gocardless.period === 'monthly' ||
+		moment.utc(user.memberPermission.date_expires).diff(moment.utc(), 'weeks') > 2;
 }
 
 module.exports = {
-	calcSubscriptionMonthsLeft
+	calcSubscriptionMonthsLeft,
+	canChangeSubscription
 };

--- a/apps/profile/apps/direct-debit/views/active.pug
+++ b/apps/profile/apps/direct-debit/views/active.pug
@@ -32,99 +32,12 @@ block contents
 
 			h3 Change contribution
 
-			form( method='post', action='/profile/direct-debit/update-subscription').form-horizontal
-				+csrf
-
-				.form-group
-					label( for='amount' ).col-md-3.control-label New amount
-					.input-group.col-md-4
-						span.input-group-addon £
-						input( type='number', name='amount', id='amount', value=user.gocardless.amount, required, min=1, step=1 ).form-control.js-new-amount
-						span.input-group-addon / month
-
-				if user.gocardless.period === 'monthly' || monthsLeft < 1
-					input(type='hidden' name='prorate' value='false')
-
-				if user.gocardless.period === 'annually'
-					p
-						| You are on an annual payment cycle so will be charged
-						|
-						b
-							| £
-							span.js-new-amount-annual= user.gocardless.actualAmount
-							| /year
-						| .
-
-					if monthsLeft >= 1
-						p.alert.alert-info.hidden.js-new-amount-less.
-							Your contribution will change on your next payment cycle
-
-						.hidden.js-new-amount-more(data-months=monthsLeft)
-							p.alert.alert-info.
-								Your membership renews in #{monthsLeft} months, if you want to
-								start your new contribution immediately we can take a one-off
-								payment of £#[span.js-new-amount-prorated -].
-							.form-group(style="margin-bottom: 0")
-								.col-md-12
-									.radio
-										label
-											input(type='radio' name='prorate' value='true' required checked)
-											| Yes, take a one-off payment of £
-											span.js-new-amount-prorated -
-											|
-											| to start my new contribution now
-									.radio
-										label
-											input(type='radio' name='prorate' value='false' required)
-											| No, I'll wait until
-											|
-											= moment(user.memberPermission.date_expires).format('DD/MM/YYYY')
-											|
-											| to start my new contribution
-									p
-									p.small
-										a(href="#").js-new-amount-prorated-toggle How is my one-off payment calculated?
-
-									.panel.panel-default.hidden.js-new-amount-prorated-calc
-										.panel-body
-											p.
-												We calculated your one-off payment based on having
-												#[b #{monthsLeft} months] left in your payment cycle, with
-												an old contribution of
-												#[b £#{user.gocardless.actualAmount}/year] and a new
-												contribution of
-												#[b £#[span.js-new-amount-annual]/year].
-											table.table.table-condensed.text-right
-												thead
-													tr
-														th Amount
-														th Calculation
-														th Description
-												tbody
-													tr
-														td £#[span.js-new-amount-prorated-new]
-														td
-															| £
-															span.js-new-amount-annual
-															|
-															| * #{monthsLeft}/12
-														td.text-left Partial payment for new contribution
-													tr
-														td - £#[span.js-new-amount-prorated-old]
-														td £#{user.gocardless.actualAmount} * #{monthsLeft}/12
-														td.text-left Partial refund for old contribution
-													tr
-														td
-															b £#[span.js-new-amount-prorated]
-														td
-														td
-
-				p
-					button.btn.join-btn.js-new-amount-btn Update contribution
-
-				p.
-					To change your payment cycle please contact
-					#[+email('membership@thebristolcable.org')].
+			if canChange
+				include partials/change-subscription
+			else
+				p.alert.alert-warning.
+					You can't change your contribution online at the moment, please
+					contact #[+email('membership@thebristolcable.org')] for support.
 
 			hr
 

--- a/apps/profile/apps/direct-debit/views/partials/change-subscription.pug
+++ b/apps/profile/apps/direct-debit/views/partials/change-subscription.pug
@@ -1,0 +1,93 @@
+form( method='post', action='/profile/direct-debit/update-subscription').form-horizontal
+	+csrf
+
+	.form-group
+		label( for='amount' ).col-md-3.control-label New amount
+		.input-group.col-md-4
+			span.input-group-addon £
+			input( type='number', name='amount', id='amount', value=user.gocardless.amount, required, min=1, step=1 ).form-control.js-new-amount
+			span.input-group-addon / month
+
+	if user.gocardless.period === 'annually'
+		p
+			| You are on an annual payment cycle so will be charged
+			|
+			b
+				| £
+				span.js-new-amount-annual= user.gocardless.actualAmount
+				| /year
+			| .
+
+	if monthsLeft < 1
+		input(type='hidden' name='prorate' value='false')
+	else
+		p.alert.alert-info.hidden.js-new-amount-less.
+			Your contribution will change on your next payment cycle
+
+		.hidden.js-new-amount-more(data-months=monthsLeft)
+			p.alert.alert-info.
+				Your membership renews in #{monthsLeft} months, if you want to
+				start your new contribution immediately we can take a one-off
+				payment of £#[span.js-new-amount-prorated -].
+
+			.form-group(style="margin-bottom: 0")
+				.col-md-12
+					.radio
+						label
+							input(type='radio' name='prorate' value='true' required checked)
+							| Yes, take a one-off payment of £
+							span.js-new-amount-prorated -
+							|
+							| to start my new contribution now
+					.radio
+						label
+							input(type='radio' name='prorate' value='false' required)
+							| No, I'll wait until
+							|
+							= moment(user.memberPermission.date_expires).format('DD/MM/YYYY')
+							|
+							| to start my new contribution
+					p
+					p.small
+						a(href="#").js-new-amount-prorated-toggle How is my one-off payment calculated?
+
+					.panel.panel-default.hidden.js-new-amount-prorated-calc
+						.panel-body
+							p.
+								We calculated your one-off payment based on having
+								#[b #{monthsLeft} months] left in your payment cycle, with
+								an old contribution of
+								#[b £#{user.gocardless.actualAmount}/year] and a new
+								contribution of
+								#[b £#[span.js-new-amount-annual]/year].
+							table.table.table-condensed.text-right
+								thead
+									tr
+										th Amount
+										th Calculation
+										th Description
+								tbody
+									tr
+										td £#[span.js-new-amount-prorated-new]
+										td
+											| £
+											span.js-new-amount-annual
+											|
+											| * #{monthsLeft}/12
+										td.text-left Partial payment for new contribution
+									tr
+										td - £#[span.js-new-amount-prorated-old]
+										td £#{user.gocardless.actualAmount} * #{monthsLeft}/12
+										td.text-left Partial refund for old contribution
+									tr
+										td
+											b £#[span.js-new-amount-prorated]
+										td
+										td
+
+p
+	button.btn.join-btn.js-new-amount-btn Update contribution
+
+p.
+	To change your payment cycle please contact
+	#[+email('membership@thebristolcable.org')].

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -77,6 +77,7 @@
 	"flash-gocardless-subscription-cancellation-err": "Error cancelling contribution",
 	"flash-gocardless-subscription-updated": "Contribution updated",
 	"flash-gocardless-subscription-updating-same": "Your contribution amount hasn't changed",
+	"flash-gocardless-subscription-updating-not-allowed": "You can't change your contribution at the moment",
 	"flash-gocardless-subscription-updating-err": "Error updating contribution",
 	"flash-gocardless-subscription-exists": "You already have an active contribution",
 	"flash-gocardless-subscription-doesnt-exist": "You don't have an active contribution",


### PR DESCRIPTION
Direct debit payments can be created a while before they are submitted, this ensures that an annual subscription in updated in time to catch the payment