### PR TITLE
Handle GC paid_out events differently

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -108,6 +108,12 @@ async function handlePaymentResourceEvent( event ) {
 	// haven't changed though.
 	if ( event.action === 'paid_out' ) {
 		await Payments.update( { payment_id: event.links.payment }, { $set: { status: 'paid_out' } } );
+
+		log.info( {
+			app: 'webhook',
+			action: 'paid-out-payment',
+			payment_id: event.links.payment
+		} );
 	} else {
 		const gcPayment = await gocardless.payments.get( event.links.payment );
 		const payment =


### PR DESCRIPTION
Fix a problem where GC sends so many `paid_out` events that we get rate limited when we try to fetch the payment for each one