### PR TITLE
Handle invalid direct debits slightly more gracefully than a 500

### DIFF
--- a/apps/join/app.js
+++ b/apps/join/app.js
@@ -109,6 +109,14 @@ app.get( '/complete', [
 			}
 		}
 	} else {
+		req.log.error({
+			app: 'join',
+			action: 'invalid-direct-debit',
+			data: {
+				customerId: customer.id,
+				joinForm
+			}
+		});
 		res.redirect( app.mountpath + '/invalid-direct-debit' );
 	}
 }));

--- a/apps/join/app.js
+++ b/apps/join/app.js
@@ -116,7 +116,7 @@ app.get( '/complete', [
 				customerId: customer.id,
 				joinForm
 			}
-		});
+		}, 'Customer tried to sign up with invalid direct debit');
 		res.redirect( app.mountpath + '/invalid-direct-debit' );
 	}
 }));

--- a/apps/join/app.js
+++ b/apps/join/app.js
@@ -8,8 +8,8 @@ const { loginAndRedirect, wrapAsync } = require( __js + '/utils' );
 
 const config = require( __config );
 
-const { processJoinForm, customerToMember, createJoinFlow, completeJoinFlow, createMember,
-	startMembership, isGiftAvailable } = require( './utils' );
+const { processJoinForm, customerToMember, createJoinFlow, completeJoinFlow, isValidCustomer,
+	createMember, startMembership, isGiftAvailable } = require( './utils' );
 
 const { joinSchema, referralSchema, completeSchema } = require( './schemas.json' );
 
@@ -73,39 +73,43 @@ app.get( '/complete', [
 	auth.isNotLoggedIn,
 	hasSchema(completeSchema).orRedirect( '/join' )
 ], wrapAsync(async function( req, res ) {
-	const {customerId, mandateId, joinForm} = await completeJoinFlow(req.query.redirect_flow_id);
+	const {customer, mandateId, joinForm} = await completeJoinFlow(req.query.redirect_flow_id);
 
-	const memberObj = await customerToMember(customerId, mandateId);
+	if (isValidCustomer(customer)) {
+		const memberObj = customerToMember(customer, mandateId);
 
-	try {
-		const newMember = await createMember(memberObj);
-		await startMembership(newMember, joinForm);
-		await mandrill.sendToMember('welcome', newMember);
-		loginAndRedirect(req, res, newMember);
-	} catch ( saveError ) {
-		// Duplicate email
-		if ( saveError.code === 11000 ) {
-			const oldMember = await Members.findOne({email: memberObj.email});
-			if (oldMember.isActiveMember || oldMember.hasActiveSubscription) {
-				res.redirect( app.mountpath + '/duplicate-email' );
+		try {
+			const newMember = await createMember(memberObj);
+			await startMembership(newMember, joinForm);
+			await mandrill.sendToMember('welcome', newMember);
+			loginAndRedirect(req, res, newMember);
+		} catch ( saveError ) {
+			// Duplicate email
+			if ( saveError.code === 11000 ) {
+				const oldMember = await Members.findOne({email: memberObj.email});
+				if (oldMember.isActiveMember || oldMember.hasActiveSubscription) {
+					res.redirect( app.mountpath + '/duplicate-email' );
+				} else {
+					const code = auth.generateCode();
+
+					await RestartFlows.create( {
+						code,
+						member: oldMember._id,
+						customerId: customer.id,
+						mandateId,
+						joinForm
+					} );
+
+					await mandrill.sendToMember('restart-membership', oldMember, {code});
+
+					res.redirect( app.mountpath + '/expired-member' );
+				}
 			} else {
-				const code = auth.generateCode();
-
-				await RestartFlows.create( {
-					code,
-					member: oldMember._id,
-					customerId,
-					mandateId,
-					joinForm
-				} );
-
-				await mandrill.sendToMember('restart-membership', oldMember, {code});
-
-				res.redirect( app.mountpath + '/expired-member' );
+				throw saveError;
 			}
-		} else {
-			throw saveError;
 		}
+	} else {
+		res.redirect( app.mountpath + '/invalid-direct-debit' );
 	}
 }));
 
@@ -143,6 +147,10 @@ app.get('/expired-member', (req, res) => {
 
 app.get('/duplicate-email', (req, res) => {
 	res.render('duplicate-email');
+});
+
+app.get('/invalid-direct-debit', (req, res) => {
+	res.render('invalid-direct-debit');
 });
 
 module.exports = function( config ) {

--- a/apps/join/views/invalid-direct-debit.pug
+++ b/apps/join/views/invalid-direct-debit.pug
@@ -1,0 +1,19 @@
+extends /src/views/base.pug
+
+block prepend title
+	- title = "Problem starting your membership"
+
+block contents
+	+page_header( 'There was a problem starting your membership' )
+
+	.row
+		.col-md-6
+			.alert.alert-warning.
+				A contribution has not been set up, you will not be charged.
+
+			p.
+				This is most likely a problem with our system. We've been notified and
+				will be in touch to help complete the setup of your membership.
+
+			p.
+				You can also contact us at #[+email('membership@thebristolcable.org')].

--- a/apps/members/app.js
+++ b/apps/members/app.js
@@ -205,8 +205,8 @@ app.get( '/add', function( req, res ) {
 } );
 
 app.post( '/add', wrapAsync( async function( req, res ) {
-	const memberObj = await customerToMember( req.body.customer_id, req.body.mandate_id );
-	const member = await createMember( memberObj );
+	const customer = await gocardless.customers.get(req.body.customer_id);
+	const member = await createMember( customerToMember( customer, req.body.mandate_id ) );
 	res.redirect( app.mountpath + '/' + member.uuid );
 } ) );
 

--- a/apps/profile/apps/direct-debit/app.js
+++ b/apps/profile/apps/direct-debit/app.js
@@ -98,9 +98,9 @@ app.get( '/complete', [
 ], wrapAsync( async (req, res) => {
 	const { user } = req;
 
-	const { customerId, mandateId, joinForm } = await completeJoinFlow( req.query.redirect_flow_id );
-
 	if (await canChangeSubscription(user, false)) {
+		const { customer, mandateId, joinForm } = await completeJoinFlow( req.query.redirect_flow_id );
+
 		if ( user.gocardless.mandate_id ) {
 			// Remove subscription before cancelling mandate to stop the
 			// webhook triggering a cancelled email
@@ -116,7 +116,7 @@ app.get( '/complete', [
 			user.memberPermission.date_expires = nextChargeDate;
 		}
 
-		user.gocardless.customer_id = customerId;
+		user.gocardless.customer_id = customer.id;
 		user.gocardless.mandate_id = mandateId;
 		user.gocardless.subscription_id = undefined;
 		await user.save();

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -39,6 +39,7 @@
 	"flash-member-permanently-deleted": "Member permanently deleted",
 	"flash-member-login-override-generated": "Login override code generated",
 	"flash-member-password-reset-generated": "Password reset code generated",
+	"flash-member-add-invalid-direct-debit": "Invalid direct debit",
 
 	"flash-account-updated": "Your account details have been updated",
 	"flash-delivery-updated": "Your delivery details have been updated",


### PR DESCRIPTION
Direct debits can be created for companies rather than people, this is a problem as we need the first name/last name from the direct debit. Ideally we'd turn this off in GoCardless but unfortunately they don't provide that option.

Given that this happens very rarely just give the user a message and send a notification to an admin to sort it out