### PR TITLE
Fix email update failing if they weren't in MailChimp

### DIFF
--- a/apps/join/utils.js
+++ b/apps/join/utils.js
@@ -138,7 +138,7 @@ async function addToMailingLists(member) {
 		log.error({
 			app: 'join-utils',
 			error: err
-		});
+		}, 'Adding member to MailChimp failed, probably a bad email address: ' + member.uuid);
 	}
 }
 

--- a/src/js/mailchimp.js
+++ b/src/js/mailchimp.js
@@ -35,7 +35,7 @@ function createInstance(endpoint) {
 			app: 'mailchimp' + endpoint,
 			status: error.response.status,
 			data: error.response.data
-		});
+		}, 'MailChimp API returned with status ' + error.response.status);
 		return Promise.reject(error);
 	});
 

--- a/tools/mailchimp/sync.js
+++ b/tools/mailchimp/sync.js
@@ -97,7 +97,7 @@ async function processMembers(members) {
 		.map(listId => members.map(memberToOperation.bind(null, listId)))
 		.reduce((a, b) => [...a, ...b], []);
 
-	const updates = operations.filter(o => o.method === 'PUT').length;
+	const updates = operations.filter(o => o.method === 'PATCH').length;
 	const deletes = operations.filter(o => o.method === 'DELETE').length;
 
 	console.log(`Created ${operations.length} operations, ${updates} updates and ${deletes} deletes`);


### PR DESCRIPTION
Sometimes someone signs up with an invalid email address (e.g. blah@gmail.con) and MailChimp rejects them. We still allow the sign up to continue, but then when we try to fix their email address it again fails because it can't update a MailChimp record.

This PR makes the system create the MailChimp record if it fails to update one.