### PR TITLE
Use up-to-date record to remove need for insert -> update in MailChimp

### DIFF
--- a/apps/members/app.js
+++ b/apps/members/app.js
@@ -320,22 +320,23 @@ app.post( '/:uuid/profile', [
 		firstname !== user.firstname ||
 		lastname !== user.lastname;
 
-	const profile = {
-		email: cleanedEmail,
-		firstname, lastname, delivery_optin,
-		delivery_address: delivery_optin ? {
+	try {
+		const oldEmail = user.email;
+
+		user.email = cleanedEmail;
+		user.firstname = firstname;
+		user.lastname = lastname;
+		user.delivery_optin = delivery_optin;
+		user.delivery_address = delivery_optin ? {
 			line1: delivery_line1,
 			line2: delivery_line2,
 			city: delivery_city,
 			postcode: delivery_postcode
-		} : {}
-	};
-
-	try {
-		await Members.updateOne( { uuid }, { $set: profile } );
+		} : {};
+		await user.save();
 
 		if ( needsSync ) {
-			await syncMemberDetails( user, { email, firstname, lastname } );
+			await syncMemberDetails( user, oldEmail );
 		}
 	} catch ( saveError ) {
 		// Duplicate key (on email)

--- a/apps/profile/apps/account/app.js
+++ b/apps/profile/apps/account/app.js
@@ -41,9 +41,14 @@ app.post( '/', [
 		const profile = { email: cleanedEmail, firstname, lastname };
 
 		try {
-			await user.update( { $set: profile }, { runValidators: true } );
+			const oldEmail = user.email;
 
-			await syncMemberDetails( user, profile );
+			user.email = email;
+			user.firstname = firstname;
+			user.lastname = lastname;
+			await user.save();
+
+			await syncMemberDetails(user, oldEmail);
 
 			req.log.info( {
 				app: 'profile',

--- a/apps/profile/apps/account/utils.js
+++ b/apps/profile/apps/account/utils.js
@@ -3,27 +3,19 @@ const mailchimp = require( __js + '/mailchimp' );
 
 const { addToMailingLists } = require( __apps + '/join/utils' );
 
-async function syncMemberDetails(member, {email, firstname, lastname}) {
+async function syncMemberDetails(member, oldEmail) {
 	if ( member.isActiveMember ) {
 		try {
-			await mailchimp.defaultLists.members.update( member.email, {
-				email_address: email,
+			await mailchimp.defaultLists.members.update( oldEmail, {
+				email_address: member.email,
 				merge_fields: {
-					FNAME: firstname,
-					LNAME: lastname
+					FNAME: member.firstname,
+					LNAME: member.lastname
 				}
 			} );
 		} catch (err) {
 			if (err.response && err.response.status === 404) {
-				// TMPFIX: Insert with old email address then overwrite
 				await addToMailingLists(member);
-				await mailchimp.defaultLists.members.update( member.email, {
-					email_address: email,
-					merge_fields: {
-						FNAME: firstname,
-						LNAME: lastname
-					}
-				} );
 			} else {
 				throw err;
 			}
@@ -32,9 +24,9 @@ async function syncMemberDetails(member, {email, firstname, lastname}) {
 
 	if ( member.gocardless.customer_id ) {
 		await gocardless.customers.update( member.gocardless.customer_id, {
-			email,
-			given_name: firstname,
-			family_name: lastname
+			email: member.email,
+			given_name: member.firstname,
+			family_name: member.lastname
 		} );
 	}
 }


### PR DESCRIPTION
The last PR #181 failed because MailChimp rejected the insert -> update idea. This fixes that