### PR TITLE
Improve deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - image: cimg/node:12.16.3
     steps:
       - checkout
-      - run: npm install
+      - run: npm ci
       - run: cp config/example-config.json config/config.json
       - run: npm run checkDependencies
       - run: NODE_ENV=production npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ aliases:
       - add_ssh_keys:
           fingerprints:
             - "91:82:53:47:f7:25:77:ab:59:9a:d1:62:c0:f9:0e:2b"
-      - run: cat /tmp/workspace/build.zip | ssh $SSH_REMOTE_HOST "$CIRCLE_BUILD_NUM.zip $STAGE"
+      - run: cat /tmp/workspace/build.tar.gz | ssh $SSH_REMOTE_HOST "$CIRCLE_BUILD_NUM.tar.gz $STAGE"
 
 jobs:
   build:
@@ -26,13 +26,13 @@ jobs:
       - run: NODE_ENV=production npm run build
       - run: npm ci --production
       - run: echo -n ${CIRCLE_SHA1:0:7} > built/revision.txt
-      - run: zip -r build.zip node_modules package.json package-lock.json built/
+      - run: tar -cvfz build.tar.gz node_modules package.json package-lock.json built/
       - persist_to_workspace:
           root: .
           paths:
-            - build.zip
+            - build.tar.gz
       - store_artifacts:
-          path: build.zip
+          path: build.tar.gz
   deploy-live:
     <<: *deploy
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: NODE_ENV=production npm run build
       - run: npm ci --production
       - run: echo -n ${CIRCLE_SHA1:0:7} > built/revision.txt
-      - run: tar -cvfz build.tar.gz node_modules package.json package-lock.json built/
+      - run: tar -cvzf build.tar.gz node_modules package.json package-lock.json built/
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run: cp config/example-config.json config/config.json
       - run: npm run checkDependencies
       - run: NODE_ENV=production npm run build
-      - run: NODE_ENV=production npm prune
+      - run: npm ci --production
       - run: echo -n ${CIRCLE_SHA1:0:7} > built/revision.txt
       - run: zip -r build.zip node_modules package.json package-lock.json built/
       - persist_to_workspace:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:12.16.3
 WORKDIR /
 ADD package.json package-lock.json ./
 
-RUN npm install --only=production
+RUN npm ci --only=production
 
 WORKDIR /membership-system
 


### PR DESCRIPTION
Use `npm ci` for a more predictable install and switch from `zip` to `tar` to preserve symlinks in `node_modules`.

The latter was causing the TypeORM CLI to not find it's dependencies because `./node_modules/.bin/typeorm` is normally a symlink but wasn't... very frustrating!