### PR TITLE
Add path to serve uploads

### DIFF
--- a/router/default.conf
+++ b/router/default.conf
@@ -37,6 +37,11 @@ server {
       gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
   }
 
+  location /uploads {
+      root /opt/membership-system/built/;
+      gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
+  }
+
   location / {
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Small change that allows us to mount a volume to `/opt/membership-system/built/uploads` to serve uploads from the container host. In our case the volume is NFS mounted